### PR TITLE
Metabolomics filter bugfix

### DIFF
--- a/minedatabase/filters/metabolomics.py
+++ b/minedatabase/filters/metabolomics.py
@@ -208,7 +208,10 @@ class MetabolomicsFilter(Filter):
         # Get compounds to keep
         cpd_info = [(cpd["_id"], cpd["SMILES"]) for cpd in compounds_to_check]
 
-        possible_ranges = self.metabolomics_dataset.possible_ranges['+'] + self.metabolomics_dataset.possible_ranges['-']
+        possible_ranges = (
+            self.metabolomics_dataset.possible_ranges["+"]
+            + self.metabolomics_dataset.possible_ranges["-"]
+        )
 
         filter_by_mass_and_rt_partial = partial(
             self._filter_by_mass_and_rt, possible_ranges

--- a/minedatabase/filters/metabolomics.py
+++ b/minedatabase/filters/metabolomics.py
@@ -133,7 +133,7 @@ class MetabolomicsFilter(Filter):
                 name=row["Peak ID"],
                 r_time=row["Retention Time"],
                 mz=row["Aggregate M/Z"],
-                charge=row["Polarity"].capitalize(),
+                charge=row["Polarity"],
                 inchi_key=inchi_key,
             )
 
@@ -208,7 +208,7 @@ class MetabolomicsFilter(Filter):
         # Get compounds to keep
         cpd_info = [(cpd["_id"], cpd["SMILES"]) for cpd in compounds_to_check]
 
-        possible_ranges = self.metabolomics_dataset.possible_ranges
+        possible_ranges = self.metabolomics_dataset.possible_ranges['+'] + self.metabolomics_dataset.possible_ranges['-']
 
         filter_by_mass_and_rt_partial = partial(
             self._filter_by_mass_and_rt, possible_ranges

--- a/minedatabase/metabolomics.py
+++ b/minedatabase/metabolomics.py
@@ -106,8 +106,8 @@ class MetabolomicsDataset:
         self.total_formulas = 0
         self.total_hits = 0
         self.matched_peaks = 0
-        self.possible_masses = {'+': [], '-': []}
-        self.possible_ranges = {'+': [], '-': []}
+        self.possible_masses = {"+": [], "-": []}
+        self.possible_ranges = {"+": [], "-": []}
 
     def __str__(self) -> str:
         """Give string representation.
@@ -155,16 +155,18 @@ class MetabolomicsDataset:
             Mass tolerance in Daltons.
         """
         for peak in self.unknown_peaks:
-            if peak.charge == '+':
+            if peak.charge == "+":
                 peak_adducts = self.pos_adducts
             else:
                 peak_adducts = self.neg_adducts
-            
-            masses, ranges = peak._enumerate_possible_masses(self, peak_adducts, tolerance)
+
+            masses, ranges = peak._enumerate_possible_masses(
+                self, peak_adducts, tolerance
+            )
             self.possible_masses[peak.charge] += masses
             self.possible_ranges[peak.charge] += ranges
 
-        for charge in ['+', '-']:
+        for charge in ["+", "-"]:
             self.possible_masses[charge] = np.array(set(self.possible_masses[charge]))
 
     def get_rt(self, peak_id: str) -> Optional[float]:
@@ -502,7 +504,9 @@ class Peak:
             f"Contains {len(self.ms2peaks)} MS2 peaks starting with {self.ms2peaks[:3]}..."
         )
 
-    def _enumerate_possible_masses(self, met_dataset: MetabolomicsDataset, adducts: List[str], tolerance: float) -> (List[float], List[Tuple[float, float]]):
+    def _enumerate_possible_masses(
+        self, met_dataset: MetabolomicsDataset, adducts: List[str], tolerance: float
+    ) -> (List[float], List[Tuple[float, float]]):
         """Generate all possible masses for a given peak.
 
         Parameters
@@ -523,7 +527,7 @@ class Peak:
         """
         possible_masses = []
         possible_ranges = []
-        if self.charge == '+':
+        if self.charge == "+":
             adducts = met_dataset.pos_adducts
         else:
             adducts = met_dataset.neg_adducts
@@ -571,7 +575,7 @@ class Peak:
         """
         if not self.ms2peaks:
             raise ValueError("The ms2 peak list is empty")
-        if self.charge:
+        if self.charge == "+":
             spec_key = "Pos_CFM_spectra"
         else:
             spec_key = "Neg_CFM_spectra"

--- a/tests/data/test_metabolomics/test_metabolomics_data.csv
+++ b/tests/data/test_metabolomics/test_metabolomics_data.csv
@@ -1,4 +1,4 @@
 Peak ID,Retention Time,Aggregate M/Z,Polarity,Compound Name,Predicted Structure (smiles),ID
-Test1,19.82,62.05983021,positive,,,no
-Test2,4.33,115.00477753,negative,succinate,O=C([O-])CCC(=O)[O-],yes
-Test3,26.29,253.09337,positive,,,no
+Test1,19.82,62.05983021,+,,,no
+Test2,4.33,115.00477753,-,succinate,O=C([O-])CCC(=O)[O-],yes
+Test3,26.29,253.09337,+,,,no

--- a/tests/test_unit/feas_test.py
+++ b/tests/test_unit/feas_test.py
@@ -7,14 +7,14 @@ cwd = Path(__file__).parent
 
 data_path = cwd / "../../tests/data/test_filters"
 pk = Pickaxe(
-        rule_list= data_path / "test_filter_rules.tsv",
-        coreactant_list= data_path / "metacyc_coreactants.tsv",
-        filter_after_final_gen=True,
-        quiet=True
-    )
+    rule_list=data_path / "test_filter_rules.tsv",
+    coreactant_list=data_path / "metacyc_coreactants.tsv",
+    filter_after_final_gen=True,
+    quiet=True,
+)
 pk.load_compound_set(data_path / "test_filter_compounds.csv")
 pk.load_targets(data_path / "test_filter_targets.csv")
-    
+
 _filter = ReactionFeasibilityFilter(use_unpredicted=False)
 pk.filters.append(_filter)
 pk.transform_all(generations=1)

--- a/tests/test_unit/test_filters.py
+++ b/tests/test_unit/test_filters.py
@@ -221,7 +221,7 @@ def test_thermo_phys(pk_target):
     pk_target.transform_all(generations=1)
 
     assert True
-    
+
 
 def test_met_filter_mass(pk_target):
     """Test MetabolomicsFilter output without RT predictor."""

--- a/tests/test_unit/test_metabolomics.py
+++ b/tests/test_unit/test_metabolomics.py
@@ -40,14 +40,14 @@ def known_peaks():
         name="Test1Known",
         r_time=5.00,
         mz=867.1391,
-        charge=True,
+        charge="+",
         inchi_key="IRPOHFRNKHKIQA-UHFFFAOYSA-N",
     )
     peak2 = Peak(
         name="Test2Known",
         r_time=8.00,
         mz=260.0297,
-        charge=False,
+        charge="-",
         inchi_key="HXXFSFRBOHSIMQ-FPRJBGLDSA-N",
     )
     return [peak1, peak2]
@@ -60,14 +60,14 @@ def unknown_peaks():
         name="Test1Unknown",
         r_time=3.00,
         mz=427.0294,
-        charge=True,
+        charge="+",
         ms2=[(10, 110), (20, 320), (25, 5)],
     )
     peak2 = Peak(
         name="Test2Unknown",
         r_time=1.50,
         mz=180.0000,
-        charge=False,
+        charge="-",
         ms2=[(10, 105), (20, 50), (25, 90)],
     )
     return [peak1, peak2]
@@ -130,18 +130,14 @@ def test_metabolomics_dataset_enumerate_possible_masses(metabolomics_dataset):
     """
     metabolomics_dataset.enumerate_possible_masses(tolerance=0.001)
     # possible masses are each peak mass +/- each adduct
-    possible_masses = set([178.992724, 181.007276, 426.022124, 428.036676])
+    possible_masses = {"+": set([426.022124]), "-": set([181.007276])}
     assert metabolomics_dataset.possible_masses == possible_masses
     # possible ranges are possible masses +/- tolerance
-    possible_ranges = set(
-        [
-            (426.02112400000004, 426.023124, "Test1Unknown", "[M+H]+"),
-            (428.035676, 428.037676, "Test1Unknown", "[M-H]-"),
-            (178.991724, 178.99372400000001, "Test2Unknown", "[M+H]+"),
-            (181.00627599999999, 181.008276, "Test2Unknown", "[M-H]-"),
-        ]
-    )
-    assert set(metabolomics_dataset.possible_ranges) == possible_ranges
+    possible_ranges = {
+        "+": [(426.02112400000004, 426.023124, "Test1Unknown", "[M+H]+")],
+        "-": [(181.00627599999999, 181.008276, "Test2Unknown", "[M-H]-")],
+    }
+    assert metabolomics_dataset.possible_ranges == possible_ranges
 
 
 def test_metabolomics_dataset_get_rt(metabolomics_dataset):

--- a/tests/test_unit/test_thermodynamics.py
+++ b/tests/test_unit/test_thermodynamics.py
@@ -22,12 +22,12 @@ if sqlite_loc.is_file():
         try:
             thermo.load_thermo_from_postgres()
             loaded_db = True
-            print('Thermo DB loaded from Postgres')
+            print("Thermo DB loaded from Postgres")
         except:
             try:
                 thermo.load_thermo_from_sqlite()
                 loaded_db = True
-                print('Thermo DB loaded from SQLite')
+                print("Thermo DB loaded from SQLite")
             except:
                 pass
     except:


### PR DESCRIPTION
Updated metabolomics filter so that it only uses adducts whose charge matches the charge of the peak.

Updated metabolomics filter tests accordingly.

Metabolomics data required for filter now has to have '+' or '-' under the 'Polarity' column rather than 'positive' or 'negative'

Changed _apply_filter logic to only apply if compounds or reactions to check/remove exist