### PR TITLE
Fixed issues of compatibility with modern python versions

### DIFF
--- a/minedatabase/filters/similarity.py
+++ b/minedatabase/filters/similarity.py
@@ -395,7 +395,9 @@ class SimilaritySamplingFilter(Filter):
         for mol_chunk in Chunks(mol_info, 10000):
             # Construct targets to sample df
             temp_df = pd.DataFrame(mol_chunk, columns=["_id", "SMILES"])
-            df = df.append(_parallelize_dataframe(temp_df, partial_T_calc, processes))
+            df = pd.concat(
+                [df, _parallelize_dataframe(temp_df, partial_T_calc, processes)]
+            )
 
         # Reset index for CDF calculation
         df.reset_index(inplace=True, drop=True)
@@ -733,6 +735,7 @@ class SimilarityFilter(Filter):
 
         Returns cpd_id if a the compound is similar enough to a target.
         """
+
         # Generate the fingerprint of a compound and compare to the fingerprints
         # of the targets
         def fingerprint(fingerprint_method, keyword_dict, smi):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,9 @@
 [options]
-python_requires = >= 3.7, <3.10
 install_requires =
     keras
     python-libsbml
-    lxml==4.9
-    mordred==1.2
+    lxml
+    mordred
     pandas
     pymongo
     rdkit

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,5 @@ setup(name='minedatabase',
           'License :: OSI Approved :: MIT License',
           'Topic :: Scientific/Engineering :: Bio-Informatics',
           'Topic :: Scientific/Engineering :: Chemistry',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.9',
-          'Programming Language :: Python :: 3.8',
       ],
       )


### PR DESCRIPTION
Hi - now, if I try to install your package on Python 3.12, I get weird Fortran-related issues as it tries to recompile all of the dependencies, including Scipy.

The solution is relatively easy: to use the current version of all packages involved and remove the old version requirements. I have therefore updated the pandas API that was breaking, and now it is straightforward to install on newer Python editions, plus all tests are passing.