### PR TITLE
Added method to add a single molecule to the Pickaxe object

### DIFF
--- a/minedatabase/exceptions.py
+++ b/minedatabase/exceptions.py
@@ -1,0 +1,15 @@
+"""Submodule providing exceptions used in the mine database package."""
+from rdkit.Chem import Mol
+from rdkit.Chem import MolToSmiles
+
+
+class DisconnectedMoleculeException(ValueError):
+    """Exception raised when a molecule is disconnected."""
+    def __init__(self, molecule: Mol):
+        molecule_smile = MolToSmiles(molecule)
+        super().__init__((
+            f"The provided molecule with SMILES '{molecule_smile}' is "
+            "disconnected. This is most common when compounds are salts. "
+            "If you want to include disconnected molecules, you can set "
+            "the `fragmented_mols` parameter to True."
+        ))

--- a/minedatabase/filters/similarity.py
+++ b/minedatabase/filters/similarity.py
@@ -395,7 +395,9 @@ class SimilaritySamplingFilter(Filter):
         for mol_chunk in Chunks(mol_info, 10000):
             # Construct targets to sample df
             temp_df = pd.DataFrame(mol_chunk, columns=["_id", "SMILES"])
-            df = df.append(_parallelize_dataframe(temp_df, partial_T_calc, processes))
+            df = pd.concat(
+                [df, _parallelize_dataframe(temp_df, partial_T_calc, processes)]
+            )
 
         # Reset index for CDF calculation
         df.reset_index(inplace=True, drop=True)
@@ -733,6 +735,7 @@ class SimilarityFilter(Filter):
 
         Returns cpd_id if a the compound is similar enough to a target.
         """
+
         # Generate the fingerprint of a compound and compare to the fingerprints
         # of the targets
         def fingerprint(fingerprint_method, keyword_dict, smi):

--- a/minedatabase/pickaxe.py
+++ b/minedatabase/pickaxe.py
@@ -191,8 +191,9 @@ class Pickaxe:
         # cid options
         self.cid_num_inchi_blocks = inchikey_blocks_for_cid
 
-        print("----------------------------------------")
-        print("Intializing pickaxe object")
+        if not self.quiet:
+            print("----------------------------------------")
+            print("Intializing pickaxe object")
         if database:
             # Determine if a specified database is legal
             db = MINE(database, self.mongo_uri)
@@ -200,24 +201,26 @@ class Pickaxe:
                 if database_overwrite:
                     # If db exists, remove db from all of core compounds
                     # and drop db
-                    print(
-                        (
-                            f"Database {database} already exists. "
-                            "Deleting database and removing from core compound"
-                            " mines."
+                    if not self.quiet:
+                        print(
+                            (
+                                f"Database {database} already exists. "
+                                "Deleting database and removing from core compound"
+                                " mines."
+                            )
                         )
-                    )
                     db.core_compounds.update_many({}, {"$pull": {"MINES": database}})
                     db.client.drop_database(database)
                     self.mine = database
                 else:
-                    print(
-                        (
-                            f"Warning! Database {database} already exists."
-                            "Specify database_overwrite as true to delete "
-                            "old database and write new."
+                    if not self.quiet:
+                        print(
+                            (
+                                f"Warning! Database {database} already exists."
+                                "Specify database_overwrite as true to delete "
+                                "old database and write new."
+                            )
                         )
-                    )
                     exit("Exiting due to database name collision.")
             else:
                 self.mine = database
@@ -240,8 +243,9 @@ class Pickaxe:
         if rule_list:
             self._load_operators(rule_list)
 
-        print("\nDone intializing pickaxe object")
-        print("----------------------------------------\n")
+        if not self.quiet:
+            print("\nDone intializing pickaxe object")
+            print("----------------------------------------\n")
 
     def load_targets(
         self,
@@ -500,11 +504,12 @@ class Pickaxe:
                         rule["Reactants"]
                     ) or rxn.GetNumProductTemplates() != len(rule["Products"]):
                         skipped += 1
-                        print(
-                            "The number of coreactants does not match the "
-                            "number of compounds in the SMARTS for reaction "
-                            "rule: " + rule["Name"]
-                        )
+                        if self.errors:
+                            print(
+                                "The number of coreactants does not match the "
+                                "number of compounds in the SMARTS for reaction "
+                                "rule: " + rule["Name"]
+                            )
                     if rule["Name"] in self.operators:
                         raise ValueError("Duplicate reaction rule name")
                     # Update reaction rules dictionary

--- a/minedatabase/pickaxe.py
+++ b/minedatabase/pickaxe.py
@@ -720,9 +720,10 @@ class Pickaxe:
 
                     # Prune network to only things being expanded
                     self.prune_network(white_list, True)
-
-                print("----------------------------------------")
-                print(f"Expanding Generation {self.generation + 1}\n")
+                
+                if not self.quiet:
+                    print("----------------------------------------")
+                    print(f"Expanding Generation {self.generation + 1}\n")
 
                 # Starting time for expansion
                 time_init = time.time()
@@ -741,23 +742,25 @@ class Pickaxe:
                 ]
                 # No compounds found
                 if not compound_smiles:
-                    print(
-                        "No compounds to expand in generation "
-                        f"{self.generation + 1}. Finished expanding."
-                    )
+                    if not self.quiet:
+                        print(
+                            "No compounds to expand in generation "
+                            f"{self.generation + 1}. Finished expanding."
+                        )
                     return None
 
                 self._transform_helper(compound_smiles, processes)
                 self._remove_cofactor_redundancy()
 
-                print(
-                    f"Generation {self.generation + 1} finished in"
-                    f" {time.time()-time_init} s and contains:"
-                )
-                print(f"\t\t{len(self.compounds) - n_comps} new compounds")
-                print(f"\t\t{len(self.reactions) - n_rxns} new reactions")
-                print(f"\nDone expanding Generation: {self.generation + 1}.")
-                print("----------------------------------------\n")
+                if not self.quiet:
+                    print(
+                        f"Generation {self.generation + 1} finished in"
+                        f" {time.time()-time_init} s and contains:"
+                    )
+                    print(f"\t\t{len(self.compounds) - n_comps} new compounds")
+                    print(f"\t\t{len(self.reactions) - n_rxns} new reactions")
+                    print(f"\nDone expanding Generation: {self.generation + 1}.")
+                    print("----------------------------------------\n")
 
             self.generation += 1
 

--- a/minedatabase/pickaxe.py
+++ b/minedatabase/pickaxe.py
@@ -13,7 +13,7 @@ from argparse import ArgumentParser
 from io import StringIO
 from pathlib import Path, PosixPath, WindowsPath
 from sys import exit
-from typing import List, Set, Tuple, Union
+from typing import List, Set, Tuple, Union, Optional
 
 import libsbml
 import lxml.etree as etree

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,9 @@
 [options]
-python_requires = >= 3.7, <3.10
 install_requires =
     keras
     python-libsbml
-    lxml==4.9
-    mordred==1.2
+    lxml
+    mordred
     pandas
     pymongo
     rdkit

--- a/setup.py
+++ b/setup.py
@@ -5,27 +5,35 @@ from setuptools import setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setup(name='minedatabase',
-      version='2.2.0',
-      description='Metabolic In silico Network Expansions',
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      url='https://github.com/tyo-nu/MINE-Database',
-      author='Kevin Shebek, Jonathan Strutz',
-      author_email='jonstrutz11@gmail.com',
-      license='MIT',
-      packages=setuptools.find_packages(exclude=["docs", "tests"]),
+setup(
+    name="minedatabase",
+    version="2.2.0",
+    description="Metabolic In silico Network Expansions",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/tyo-nu/MINE-Database",
+    author="Kevin Shebek, Jonathan Strutz",
+    author_email="jonstrutz11@gmail.com",
+    license="MIT",
+    packages=setuptools.find_packages(exclude=["docs", "tests"]),
     #   install_requires=['pymongo'],#, 'rdkit', 'scikit-learn'],
-      package_data={'minedatabase': ['data/*'],
-                    'minedatabase.NP_Score': ['*.gz'],
-                    'minedatabase.tests': ['data/*'],
-                    },
-      include_package_data=True,
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: MIT License',
-          'Topic :: Scientific/Engineering :: Bio-Informatics',
-          'Topic :: Scientific/Engineering :: Chemistry',
-      ],
-      )
+    package_data={
+        "minedatabase": [
+            "data/*/*.tsv",
+            "data/feasibility/final_model.h5",
+            "data/feasibility/vae_model.pth",
+            "data/feasibility/final_model.json",
+            "data/*/*.txt",
+        ],
+        "minedatabase.NP_Score": ["*.gz"],
+        "minedatabase.tests": ["data/*"],
+    },
+    include_package_data=True,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+        "Topic :: Scientific/Engineering :: Chemistry",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,5 @@ setup(name='minedatabase',
           'License :: OSI Approved :: MIT License',
           'Topic :: Scientific/Engineering :: Bio-Informatics',
           'Topic :: Scientific/Engineering :: Chemistry',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.9',
-          'Programming Language :: Python :: 3.8',
       ],
       )


### PR DESCRIPTION
As per title, introduced a method `add_molecule` to add a single molecule to the Pickaxe without having to store it to a file and load it. Be aware that this pull request builds on top of #43 